### PR TITLE
イコール位置を可変にできるよう変更 fix #12

### DIFF
--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -1,5 +1,4 @@
 <script lang="ts">
-import { parse } from 'path'
 import { defineComponent, ref, computed, version } from 'vue'
 import Key from "./Key.vue"
 
@@ -7,46 +6,54 @@ import Key from "./Key.vue"
 export default defineComponent({
     setup() {
 
-        const RIGHT_LEN = 3
-        const LEFT_LEN = 3
+        const RIGHT_LEN = 4
+        const LEFT_LEN = 4
+        const N_ROW = 5
+
+        const EXPR_LEN = LEFT_LEN + RIGHT_LEN + 1
+
 
         const answer = ref("")
         const row_idx = ref(0)
         const col_idx = ref(0)
-        const lines = ref(
-            [
-                {
-                    left: ["", "", ""],
-                    right: ["", "", ""]
-                },
-                {
-                    left: ["", "", ""],
-                    right: ["", "", ""]
-                },
-                {
-                    left: ["", "", ""],
-                    right: ["", "", ""]
-                },
-                {
-                    left: ["", "", ""],
-                    right: ["", "", ""]
-                },
-                {
-                    left: ["", "", ""],
-                    right: ["", "", ""]
+
+
+        function init_line(left_len: number, right_len: number, n_row: number): { left: string[], right: string[] }[] {
+            let result = []
+            let _left = []
+            let _right = []
+            for (let i = 0; i < n_row; i++) {
+                _left = []
+                _right = []
+                for (let j = 0; j < left_len; j++) {
+                    _left.push("")
                 }
-            ]
-        )
+                for (let j = 0; j < right_len; j++) {
+                    _right.push("")
+                }
+                result.push({
+                    left: _left,
+                    right: _right
+                })
+            }
+            return result
+        }
 
 
+        function init_result(left_len: number, right_len: number, n_row: number): Array<Array<string>> {
+            let result = []
+            for (let i = 0; i < n_row; i++) {
+                let _row = []
+                for (let j = 0; j < left_len + right_len; j++) {
+                    _row.push("")
+                }
+                result.push(_row)
+            }
+            return result
+        }
 
-        const results = ref([
-            ["-", "-", "-", "-", "-", "-"],
-            ["-", "-", "-", "-", "-", "-"],
-            ["-", "-", "-", "-", "-", "-"],
-            ["-", "-", "-", "-", "-", "-"],
-            ["-", "-", "-", "-", "-", "-"]
-        ])
+        const lines = ref(init_line(LEFT_LEN, RIGHT_LEN, N_ROW))
+        const results = ref(init_result(LEFT_LEN, RIGHT_LEN, N_ROW))
 
 
         const result_by_value = ref([
@@ -105,6 +112,8 @@ export default defineComponent({
                 return results.value.map(result => result.map(e => e === "x"))
             }
         )
+
+
 
 
         function judge(left: string, right: string) {
@@ -174,7 +183,7 @@ export default defineComponent({
         }
 
         const zero_is_collect = true
-        return { lines, answer, update, row_idx, col_idx, results, isCollect, isHalfCollect, isnotCollect, zero_is_collect, result_by_value, isCollect_by_value, isHalfCollect_by_value, isnotCollect_by_value, LEFT_LEN, RIGHT_LEN }
+        return { lines, answer, update, row_idx, col_idx, results, isCollect, isHalfCollect, isnotCollect, zero_is_collect, result_by_value, isCollect_by_value, isHalfCollect_by_value, isnotCollect_by_value, LEFT_LEN, RIGHT_LEN, EXPR_LEN, N_ROW }
     },
     components: {
         Key
@@ -203,22 +212,50 @@ export default defineComponent({
 
     <div class="keyboard">
         <div class="numbers">
-            <Key char="0" v-bind:class="{ correct: isCollect_by_value[0], half: isHalfCollect_by_value[0], notcollect: isnotCollect_by_value[0] }" :input="update"></Key>
-            <Key char="1" v-bind:class="{ correct: isCollect_by_value[1], half: isHalfCollect_by_value[1], notcollect: isnotCollect_by_value[1] }" :input="update"></Key>
-            <Key char="2" v-bind:class="{ correct: isCollect_by_value[2], half: isHalfCollect_by_value[2], notcollect: isnotCollect_by_value[2] }" :input="update"></Key>
-            <Key char="3" v-bind:class="{ correct: isCollect_by_value[3], half: isHalfCollect_by_value[3], notcollect: isnotCollect_by_value[3] }" :input="update"></Key>
-            <Key char="4" v-bind:class="{ correct: isCollect_by_value[4], half: isHalfCollect_by_value[4], notcollect: isnotCollect_by_value[4] }" :input="update"></Key>
-            <Key char="5" v-bind:class="{ correct: isCollect_by_value[5], half: isHalfCollect_by_value[5], notcollect: isnotCollect_by_value[5] }" :input="update"></Key>
-            <Key char="6" v-bind:class="{ correct: isCollect_by_value[6], half: isHalfCollect_by_value[6], notcollect: isnotCollect_by_value[6] }" :input="update"></Key>
-            <Key char="7" v-bind:class="{ correct: isCollect_by_value[7], half: isHalfCollect_by_value[7], notcollect: isnotCollect_by_value[7] }" :input="update"></Key>
-            <Key char="8" v-bind:class="{ correct: isCollect_by_value[8], half: isHalfCollect_by_value[8], notcollect: isnotCollect_by_value[8] }" :input="update"></Key>
-            <Key char="9" v-bind:class="{ correct: isCollect_by_value[9], half: isHalfCollect_by_value[9], notcollect: isnotCollect_by_value[9] }" :input="update"></Key>
+            <Key char="0"
+                v-bind:class="{ correct: isCollect_by_value[0], half: isHalfCollect_by_value[0], notcollect: isnotCollect_by_value[0] }"
+                :input="update"></Key>
+            <Key char="1"
+                v-bind:class="{ correct: isCollect_by_value[1], half: isHalfCollect_by_value[1], notcollect: isnotCollect_by_value[1] }"
+                :input="update"></Key>
+            <Key char="2"
+                v-bind:class="{ correct: isCollect_by_value[2], half: isHalfCollect_by_value[2], notcollect: isnotCollect_by_value[2] }"
+                :input="update"></Key>
+            <Key char="3"
+                v-bind:class="{ correct: isCollect_by_value[3], half: isHalfCollect_by_value[3], notcollect: isnotCollect_by_value[3] }"
+                :input="update"></Key>
+            <Key char="4"
+                v-bind:class="{ correct: isCollect_by_value[4], half: isHalfCollect_by_value[4], notcollect: isnotCollect_by_value[4] }"
+                :input="update"></Key>
+            <Key char="5"
+                v-bind:class="{ correct: isCollect_by_value[5], half: isHalfCollect_by_value[5], notcollect: isnotCollect_by_value[5] }"
+                :input="update"></Key>
+            <Key char="6"
+                v-bind:class="{ correct: isCollect_by_value[6], half: isHalfCollect_by_value[6], notcollect: isnotCollect_by_value[6] }"
+                :input="update"></Key>
+            <Key char="7"
+                v-bind:class="{ correct: isCollect_by_value[7], half: isHalfCollect_by_value[7], notcollect: isnotCollect_by_value[7] }"
+                :input="update"></Key>
+            <Key char="8"
+                v-bind:class="{ correct: isCollect_by_value[8], half: isHalfCollect_by_value[8], notcollect: isnotCollect_by_value[8] }"
+                :input="update"></Key>
+            <Key char="9"
+                v-bind:class="{ correct: isCollect_by_value[9], half: isHalfCollect_by_value[9], notcollect: isnotCollect_by_value[9] }"
+                :input="update"></Key>
         </div>
         <div class="operator">
-            <Key char="+" v-bind:class="{ correct: isCollect_by_value[10], half: isHalfCollect_by_value[10], notcollect: isnotCollect_by_value[10] }" :input="update"></Key>
-            <Key char="-" v-bind:class="{ correct: isCollect_by_value[11], half: isHalfCollect_by_value[11], notcollect: isnotCollect_by_value[11] }" :input="update"></Key>
-            <Key char="*" v-bind:class="{ correct: isCollect_by_value[12], half: isHalfCollect_by_value[12], notcollect: isnotCollect_by_value[12] }" :input="update"></Key>
-            <Key char="/" v-bind:class="{ correct: isCollect_by_value[13], half: isHalfCollect_by_value[13], notcollect: isnotCollect_by_value[13] }" :input="update"></Key>
+            <Key char="+"
+                v-bind:class="{ correct: isCollect_by_value[10], half: isHalfCollect_by_value[10], notcollect: isnotCollect_by_value[10] }"
+                :input="update"></Key>
+            <Key char="-"
+                v-bind:class="{ correct: isCollect_by_value[11], half: isHalfCollect_by_value[11], notcollect: isnotCollect_by_value[11] }"
+                :input="update"></Key>
+            <Key char="*"
+                v-bind:class="{ correct: isCollect_by_value[12], half: isHalfCollect_by_value[12], notcollect: isnotCollect_by_value[12] }"
+                :input="update"></Key>
+            <Key char="/"
+                v-bind:class="{ correct: isCollect_by_value[13], half: isHalfCollect_by_value[13], notcollect: isnotCollect_by_value[13] }"
+                :input="update"></Key>
         </div>
         <div class="special">
             <Key char="delete" :input="update"></Key>
@@ -232,14 +269,14 @@ export default defineComponent({
 <style scoped>
 .row {
     display: grid;
-    grid-template-columns: repeat(7, 1fr);
+    grid-template-columns: repeat(v-bind(EXPR_LEN), 1fr);
     grid-gap: 5px;
     justify-content: center;
 }
 
 .board {
     display: grid;
-    grid-template-rows: repeat(5, 1fr);
+    grid-template-rows: repeat(v-bind(N_ROW), 1fr);
     margin-top: 30px;
     grid-gap: 10px;
     height: 400px;

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -6,18 +6,46 @@ import Key from "./Key.vue"
 export default defineComponent({
     setup() {
 
-        const RIGHT_LEN = 4
-        const LEFT_LEN = 4
+        // イコールの右側にある枠の数
+        const RIGHT_LEN = 3
+        // イコールの左側にある枠の数
+        const LEFT_LEN = 3
+        // 行の数
         const N_ROW = 5
 
+        // イコールを含めた式の要素の数
         const EXPR_LEN = LEFT_LEN + RIGHT_LEN + 1
 
-
-        const answer = ref("")
+        // 現在入力中の枠が何行目か
         const row_idx = ref(0)
+        // 現在入力中の枠が何列目か
         const col_idx = ref(0)
-
-
+        
+        // left_len, right_len, n_rowから空文字列で初期化された結果を格納する配列を作る
+        //
+        // 例:init_line(3, 3, 5) -> 
+        // [
+        //     {
+        //         left: ["", "", ""],
+        //         right: ["", "", ""]
+        //     },
+        //     {
+        //         left: ["", "", ""],
+        //         right: ["", "", ""]
+        //     },
+        //     {
+        //         left: ["", "", ""],
+        //         right: ["", "", ""]
+        //     },
+        //     {
+        //         left: ["", "", ""],
+        //         right: ["", "", ""]
+        //     },
+        //     {
+        //         left: ["", "", ""],
+        //         right: ["", "", ""]
+        //     }
+        // ]
         function init_line(left_len: number, right_len: number, n_row: number): { left: string[], right: string[] }[] {
             let result = []
             let _left = []
@@ -39,7 +67,15 @@ export default defineComponent({
             return result
         }
 
-
+        // 判定の結果を格納する空文字列で初期化された二次元配列を生成する
+        // 例:init_result(3, 3, 5) ->
+        // [
+        //     ["-", "-", "-", "-", "-", "-"],
+        //     ["-", "-", "-", "-", "-", "-"],
+        //     ["-", "-", "-", "-", "-", "-"],
+        //     ["-", "-", "-", "-", "-", "-"],
+        //     ["-", "-", "-", "-", "-", "-"]
+        // ]
         function init_result(left_len: number, right_len: number, n_row: number): Array<Array<string>> {
             let result = []
             for (let i = 0; i < n_row; i++) {
@@ -52,10 +88,12 @@ export default defineComponent({
             return result
         }
 
+
         const lines = ref(init_line(LEFT_LEN, RIGHT_LEN, N_ROW))
         const results = ref(init_result(LEFT_LEN, RIGHT_LEN, N_ROW))
 
-
+        // 各値,  演算子についての判定結果を保存する配列
+        // 例えば一番最後の要素は / の判定結果を格納
         const result_by_value = ref([
             "", // 0
             "", // 1
@@ -120,8 +158,10 @@ export default defineComponent({
             return ["o", "o", "o", "h", "x", "o"]
         }
 
+        // 入力に応じて`lines`を更新して、"enter"が押されたらジャッジをする。
         function update(char: string) {
             if (char === "delete") {
+                // col_idx.value === 0 な時、まだ何も入力されていないのでスキップ
                 if (col_idx.value === 0) {
                     return
                 }
@@ -132,11 +172,16 @@ export default defineComponent({
                 }
                 col_idx.value--
             } else if (char === "return") {
+                // 入力しきっていない場合はalertを出す
                 if (col_idx.value !== (LEFT_LEN + RIGHT_LEN)) {
                     alert("plese input all")
                     return
                 }
+
+                // ジャッジする
                 results.value[row_idx.value] = judge(lines.value[row_idx.value].left.join(), lines.value[row_idx.value].right.join())
+                
+                // ジャッジ結果をresult_by_valueに代入していく。
                 for (let i = 0; i < LEFT_LEN; i++) {
                     const v = lines.value[row_idx.value].left[i]
                     if (v === "+") {
@@ -170,9 +215,10 @@ export default defineComponent({
                 row_idx.value++;
                 col_idx.value = 0;
             } else if (col_idx.value > (LEFT_LEN + RIGHT_LEN - 1)) {
-                // skip
+                // すでに入力しきっているのにさらに入力が来た場合。 なのでスキップ
                 return
             } else {
+                // 正しい入力 
                 if (col_idx.value > (LEFT_LEN - 1)) {
                     lines.value[row_idx.value].right[col_idx.value - LEFT_LEN] = char
                 } else {
@@ -182,8 +228,7 @@ export default defineComponent({
             }
         }
 
-        const zero_is_collect = true
-        return { lines, answer, update, row_idx, col_idx, results, isCollect, isHalfCollect, isnotCollect, zero_is_collect, result_by_value, isCollect_by_value, isHalfCollect_by_value, isnotCollect_by_value, LEFT_LEN, RIGHT_LEN, EXPR_LEN, N_ROW }
+        return { lines, update, row_idx, col_idx, results, isCollect, isHalfCollect, isnotCollect, result_by_value, isCollect_by_value, isHalfCollect_by_value, isnotCollect_by_value, LEFT_LEN, RIGHT_LEN, EXPR_LEN, N_ROW }
     },
     components: {
         Key


### PR DESCRIPTION
# イコールの位置を可変に
イコールの位置を可変にするために実装を変更しました。
`lines`と`results`の初期化をベタがきから変更しました。

また、
```grid-template-columns```についても、
``` repeat(v-bind(EXPR_LEN), 1fr)```のようにして式の長さの変更に対応できるようにしました。 
# デモ
(直接コードの`LEFT_LEN`などを編集してこの画面を収録しています)
![](https://media.discordapp.net/attachments/986426703855366194/986983844999745607/demo6.gif?width=717&height=686)